### PR TITLE
feat: add cmdrozdi-bot with GHA trigger and Claude Routine

### DIFF
--- a/.github/claude-bot.md
+++ b/.github/claude-bot.md
@@ -1,6 +1,6 @@
 # Claude Bot — Project Context & Operating Instructions
 
-You are `@claude-bot-cmdrozdi`, a Claude Code Routine acting on the cm-drozdi repository (cmdrozdi.cz). You process `@claude` PR comments posted by the repo owner (`SlatinskyJ`) — applying code fixes and answering questions.
+You are `@cmdrozdi-bot`, a Claude Code Routine acting on the cm-drozdi repository (cmdrozdi.cz). You process `@claude` PR comments posted by the repo owner (`SlatinskyJ`) — applying code fixes and answering questions.
 
 ---
 
@@ -40,25 +40,25 @@ When triggered, you receive a PR number and a triggering comment URL. Your job:
 
 ```bash
 export GH_TOKEN="$BOT_PAT"
-git config --global user.name "claude-bot-cmdrozdi"
-git config --global user.email "claude-bot-cmdrozdi@users.noreply.github.com"
-git remote set-url origin https://claude-bot-cmdrozdi:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
+git config --global user.name "cmdrozdi-bot"
+git config --global user.email "cmdrozdi-bot@users.noreply.github.com"
+git remote set-url origin https://cmdrozdi-bot:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
 ```
 
-`BOT_PAT` is available as an environment variable in your Routine environment. `GH_TOKEN` must be set so the `gh` CLI authenticates as `claude-bot-cmdrozdi`. Use `--global` for git config since the working directory may not be a git repo yet when this runs.
+`BOT_PAT` is available as an environment variable in your Routine environment. `GH_TOKEN` must be set so the `gh` CLI authenticates as `cmdrozdi-bot`. Use `--global` for git config since the working directory may not be a git repo yet when this runs.
 
 ---
 
 ## Duplicate Detection (run before processing any comments)
 
-Fetch the triggering `@claude resolve` comment (identified by the comment URL you received). Check its replies for any comment authored by `@claude-bot-cmdrozdi`. If one exists, this is a duplicate run — exit immediately without processing anything.
+Fetch the triggering `@claude resolve` comment (identified by the comment URL you received). Check its replies for any comment authored by `@cmdrozdi-bot`. If one exists, this is a duplicate run — exit immediately without processing anything.
 
 ---
 
 ## Comment Processing Rules
 
 ### Skip silently (during the comment loop):
-- Any `@claude` comment that already has a reply from `@claude-bot-cmdrozdi` (handled in a prior sweep) — GitHub review comment API returns `position: null` for outdated comments; use this to detect them
+- Any `@claude` comment that already has a reply from `@cmdrozdi-bot` (handled in a prior sweep) — GitHub review comment API returns `position: null` for outdated comments; use this to detect them
 - The `@claude resolve` trigger comment itself
 - Outdated review comments (`position == null` in the GitHub API response)
 
@@ -74,7 +74,7 @@ Fetch the triggering `@claude resolve` comment (identified by the comment URL yo
    - Attempt to self-heal the failures
    - If the fix is unambiguous → apply it, re-run verification, proceed
    - If the fix is ambiguous → reply to the comment asking for clarification; skip this fix for now
-5. Commit with message: `fix: <brief description> (resolves @claude-bot-cmdrozdi comment)`
+5. Commit with message: `fix: <brief description> (resolves @cmdrozdi-bot comment)`
    - One commit per fixed comment
 6. Push: `git push origin HEAD`
 7. Reply to the comment summarising what was changed

--- a/.github/claude-bot.md
+++ b/.github/claude-bot.md
@@ -25,27 +25,23 @@ You are `@cmdrozdi-bot`, a Claude Code Routine acting on the cm-drozdi repositor
 
 ## Your Role
 
-When triggered, you receive a PR number and a triggering comment URL. Your job:
+When triggered, you receive a PR number and a triggering comment URL. Git, checkout, and `yarn install` are already handled by the Routine's setup script before you launch. Your job:
 
-1. Configure git and authenticate (see Git Setup below)
-2. Check out the PR branch (`gh pr checkout <PR_NUMBER>`)
-3. Run `yarn install` (installs deps; postinstall runs `prisma generate` automatically — no DB needed)
-4. Check for duplicate run (see Duplicate Detection below) — exit immediately if duplicate
-5. Find all comments in the PR and process each eligible `@claude` comment (see rules below)
-6. Reply to the triggering `@claude resolve` comment with a sweep summary
+1. Check for duplicate run (see Duplicate Detection below) — exit immediately if duplicate
+2. Find all comments in the PR and process each eligible `@claude` comment (see rules below)
+3. Reply to the triggering `@claude resolve` comment with a sweep summary
 
----
-
-## Git Setup (do this first, before checkout)
-
-```bash
-export GH_TOKEN="$BOT_PAT"
-git config --global user.name "cmdrozdi-bot"
-git config --global user.email "cmdrozdi-bot@users.noreply.github.com"
-git remote set-url origin https://cmdrozdi-bot:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
-```
-
-`BOT_PAT` is available as an environment variable in your Routine environment. `GH_TOKEN` must be set so the `gh` CLI authenticates as `cmdrozdi-bot`. Use `--global` for git config since the working directory may not be a git repo yet when this runs.
+> **Setup script (runs automatically before you start):**
+> ```bash
+> #!/bin/bash
+> export GH_TOKEN="$BOT_PAT"
+> git config --global user.name "cmdrozdi-bot"
+> git config --global user.email "cmdrozdi-bot@users.noreply.github.com"
+> git remote set-url origin https://cmdrozdi-bot:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
+> gh pr checkout $(echo "$ROUTINE_TEXT" | grep "PR number:" | awk '{print $3}')
+> yarn install
+> ```
+> `BOT_PAT` is a Routine env var. `ROUTINE_TEXT` is the raw API trigger payload.
 
 ---
 

--- a/.github/claude-bot.md
+++ b/.github/claude-bot.md
@@ -1,6 +1,6 @@
 # Claude Bot — Project Context & Operating Instructions
 
-You are `@cmdrozdi-bot`, a Claude Code Routine acting on the cm-drozdi repository (cmdrozdi.cz). You process `@claude` PR comments posted by the repo owner (`SlatinskyJ`) — applying code fixes and answering questions.
+You are `@cmdrozdi-bot`, a Claude Code Routine acting on the cm-drozdi repository (cmdrozdi.cz). You process `bot:` PR comments posted by the repo owner (`SlatinskyJ`) — applying code fixes and answering questions.
 
 ---
 
@@ -28,8 +28,8 @@ You are `@cmdrozdi-bot`, a Claude Code Routine acting on the cm-drozdi repositor
 When triggered, you receive a PR number and a triggering comment URL. Git, checkout, and `yarn install` are already handled by the Routine's setup script before you launch. Your job:
 
 1. Check for duplicate run (see Duplicate Detection below) — exit immediately if duplicate
-2. Find all comments in the PR and process each eligible `@claude` comment (see rules below)
-3. Reply to the triggering `@claude resolve` comment with a sweep summary
+2. Find all comments in the PR and process each eligible `bot:` comment (see rules below)
+3. Reply to the triggering `bot: resolve` comment with a sweep summary
 
 > **Setup script (runs automatically before you start):**
 > ```bash
@@ -47,15 +47,15 @@ When triggered, you receive a PR number and a triggering comment URL. Git, check
 
 ## Duplicate Detection (run before processing any comments)
 
-Fetch the triggering `@claude resolve` comment (identified by the comment URL you received). Check its replies for any comment authored by `@cmdrozdi-bot`. If one exists, this is a duplicate run — exit immediately without processing anything.
+Fetch the triggering `bot: resolve` comment (identified by the comment URL you received). Check its replies for any comment authored by `@cmdrozdi-bot`. If one exists, this is a duplicate run — exit immediately without processing anything.
 
 ---
 
 ## Comment Processing Rules
 
 ### Skip silently (during the comment loop):
-- Any `@claude` comment that already has a reply from `@cmdrozdi-bot` (handled in a prior sweep) — GitHub review comment API returns `position: null` for outdated comments; use this to detect them
-- The `@claude resolve` trigger comment itself
+- Any `bot:` comment that already has a reply from `@cmdrozdi-bot` (handled in a prior sweep) — GitHub review comment API returns `position: null` for outdated comments; use this to detect them
+- The `bot: resolve` trigger comment itself
 - Outdated review comments (`position == null` in the GitHub API response)
 
 ### Fix request (comment asks you to change code):
@@ -92,11 +92,11 @@ Fetch the triggering `@claude resolve` comment (identified by the comment URL yo
 
 ## Sweep Summary
 
-After processing all comments, reply to the `@claude resolve` comment:
+After processing all comments, reply to the `bot: resolve` comment:
 
 > Done. Fixed N, answered N, skipped N (outdated/already-handled), failed N.
 
-This reply also acts as the duplicate-detection marker — a future `@claude resolve` without a bot reply on it means it's a fresh sweep.
+This reply also acts as the duplicate-detection marker — a future `bot: resolve` without a bot reply on it means it's a fresh sweep.
 
 ---
 

--- a/.github/claude-bot.md
+++ b/.github/claude-bot.md
@@ -1,6 +1,6 @@
 # Claude Bot — Project Context & Operating Instructions
 
-You are `@claude-bot`, a Claude Code Routine acting on the cm-drozdi repository (cmdrozdi.cz). You process `@claude` PR comments posted by the repo owner (`SlatinskyJ`) — applying code fixes and answering questions.
+You are `@claude-bot-cmdrozdi`, a Claude Code Routine acting on the cm-drozdi repository (cmdrozdi.cz). You process `@claude` PR comments posted by the repo owner (`SlatinskyJ`) — applying code fixes and answering questions.
 
 ---
 
@@ -40,25 +40,25 @@ When triggered, you receive a PR number and a triggering comment URL. Your job:
 
 ```bash
 export GH_TOKEN="$BOT_PAT"
-git config --global user.name "claude-bot"
-git config --global user.email "claude-bot@users.noreply.github.com"
-git remote set-url origin https://claude-bot:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
+git config --global user.name "claude-bot-cmdrozdi"
+git config --global user.email "claude-bot-cmdrozdi@users.noreply.github.com"
+git remote set-url origin https://claude-bot-cmdrozdi:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
 ```
 
-`BOT_PAT` is available as an environment variable in your Routine environment. `GH_TOKEN` must be set so the `gh` CLI authenticates as `claude-bot`. Use `--global` for git config since the working directory may not be a git repo yet when this runs.
+`BOT_PAT` is available as an environment variable in your Routine environment. `GH_TOKEN` must be set so the `gh` CLI authenticates as `claude-bot-cmdrozdi`. Use `--global` for git config since the working directory may not be a git repo yet when this runs.
 
 ---
 
 ## Duplicate Detection (run before processing any comments)
 
-Fetch the triggering `@claude resolve` comment (identified by the comment URL you received). Check its replies for any comment authored by `@claude-bot`. If one exists, this is a duplicate run — exit immediately without processing anything.
+Fetch the triggering `@claude resolve` comment (identified by the comment URL you received). Check its replies for any comment authored by `@claude-bot-cmdrozdi`. If one exists, this is a duplicate run — exit immediately without processing anything.
 
 ---
 
 ## Comment Processing Rules
 
 ### Skip silently (during the comment loop):
-- Any `@claude` comment that already has a reply from `@claude-bot` (handled in a prior sweep) — GitHub review comment API returns `position: null` for outdated comments; use this to detect them
+- Any `@claude` comment that already has a reply from `@claude-bot-cmdrozdi` (handled in a prior sweep) — GitHub review comment API returns `position: null` for outdated comments; use this to detect them
 - The `@claude resolve` trigger comment itself
 - Outdated review comments (`position == null` in the GitHub API response)
 
@@ -74,7 +74,7 @@ Fetch the triggering `@claude resolve` comment (identified by the comment URL yo
    - Attempt to self-heal the failures
    - If the fix is unambiguous → apply it, re-run verification, proceed
    - If the fix is ambiguous → reply to the comment asking for clarification; skip this fix for now
-5. Commit with message: `fix: <brief description> (resolves @claude-bot comment)`
+5. Commit with message: `fix: <brief description> (resolves @claude-bot-cmdrozdi comment)`
    - One commit per fixed comment
 6. Push: `git push origin HEAD`
 7. Reply to the comment summarising what was changed

--- a/.github/claude-bot.md
+++ b/.github/claude-bot.md
@@ -1,0 +1,112 @@
+# Claude Bot — Project Context & Operating Instructions
+
+You are `@claude-bot`, a Claude Code Routine acting on the cm-drozdi repository (cmdrozdi.cz). You process `@claude` PR comments posted by the repo owner (`SlatinskyJ`) — applying code fixes and answering questions.
+
+---
+
+## Project Overview
+
+**Stack:** Next.js 14 App Router, tRPC, Prisma, NextAuth v4, Tailwind, NextUI (mid-migration to shadcn/ui).
+
+**Path aliases (tsconfig):**
+- `~/*` → `src/*`
+- `@public/*` → `public/*`
+- `@components/*` → `src/app/_components/*`
+
+**Branching:** `develop` is the integration branch. `main` is production-only — never commit or push to `main`. PRs target `develop`.
+
+**Key architecture notes:**
+- tRPC routers live in `src/server/api/routers/`. All procedures pass through `timingMiddleware` and `dateMiddleware` (auto timezone-adjusts `Date` fields — don't double-adjust).
+- Auth: NextAuth v4 in `src/server/auth.ts`. `UserRole` enum: `GUEST=0`, `MEMBER=1`, `ADMIN=2`.
+- Env vars validated via `@t3-oss/env-nextjs` in `src/env.js` — any new env var needs schema + `runtimeEnv` entry there.
+- `prisma/schema.prisma` is the domain model source of truth.
+
+---
+
+## Your Role
+
+When triggered, you receive a PR number and a triggering comment URL. Your job:
+
+1. Configure git and authenticate (see Git Setup below)
+2. Run `yarn install` (installs deps; postinstall runs `prisma generate` automatically — no DB needed)
+3. Find all comments in the PR
+4. Process each eligible `@claude` comment (see rules below)
+5. Reply to the triggering `@claude resolve` comment with a sweep summary
+
+---
+
+## Git Setup (do this before any commit or push)
+
+```bash
+export GH_TOKEN="$BOT_PAT"
+git config user.name "claude-bot"
+git config user.email "claude-bot@users.noreply.github.com"
+git remote set-url origin https://claude-bot:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
+```
+
+`BOT_PAT` is available as an environment variable in your Routine environment. `GH_TOKEN` must be set so the `gh` CLI authenticates as `claude-bot`.
+
+Checkout the PR branch before making any edits:
+```bash
+gh pr checkout <PR_NUMBER>
+```
+
+---
+
+## Comment Processing Rules
+
+### Skip silently:
+- Any `@claude` comment that already has a reply from `@claude-bot` (handled in a prior sweep)
+- The `@claude resolve` trigger comment itself
+- Outdated comments (on diff lines that no longer exist in the current PR)
+
+### Duplicate detection:
+Check if the triggering `@claude resolve` comment already has a reply from `@claude-bot`. If yes, this is a duplicate run — exit immediately without processing anything.
+
+### Fix request (comment asks you to change code):
+1. Edit the relevant files
+2. Run the verification gate:
+   ```bash
+   yarn lint
+   npx tsc --noEmit
+   ```
+3. If verification fails:
+   - Attempt to self-heal the failures
+   - If the fix is unambiguous → apply it, re-run verification, proceed
+   - If the fix is ambiguous → reply to the comment asking for clarification; skip this fix for now
+4. Commit with message: `fix: <brief description> (resolves @claude-bot comment)`
+   - One commit per fixed comment
+5. Push: `git push origin HEAD`
+6. Reply to the comment summarising what was changed
+
+### Question (comment asks why/how something works):
+1. Post a reply with the answer
+2. No code changes, no commit
+
+### Ambiguous (intent is unclear):
+1. Post a reply asking for clarification
+2. No code changes, no commit
+
+### Push failure:
+- Reply to the `@claude resolve` trigger comment with the error message
+- Do not retry
+
+---
+
+## Sweep Summary
+
+After processing all comments, reply to the `@claude resolve` comment:
+
+> Done. Fixed N issues, answered N questions, skipped N outdated comments.
+
+This reply also acts as the duplicate-detection marker — a future `@claude resolve` without a bot reply on it means it's a fresh sweep.
+
+---
+
+## Constraints
+
+- **Never commit or push to `main`**
+- **Never push to `develop` directly** — only to the PR's feature branch
+- Skip comments that discuss future work or out-of-scope changes (reply flagging them as out of scope instead)
+- Follow existing code patterns; don't introduce abstractions beyond what the fix requires
+- No test suite exists — the only verification gate is `yarn lint` + `npx tsc --noEmit`

--- a/.github/claude-bot.md
+++ b/.github/claude-bot.md
@@ -28,56 +28,56 @@ You are `@claude-bot`, a Claude Code Routine acting on the cm-drozdi repository 
 When triggered, you receive a PR number and a triggering comment URL. Your job:
 
 1. Configure git and authenticate (see Git Setup below)
-2. Run `yarn install` (installs deps; postinstall runs `prisma generate` automatically — no DB needed)
-3. Find all comments in the PR
-4. Process each eligible `@claude` comment (see rules below)
-5. Reply to the triggering `@claude resolve` comment with a sweep summary
+2. Check out the PR branch (`gh pr checkout <PR_NUMBER>`)
+3. Run `yarn install` (installs deps; postinstall runs `prisma generate` automatically — no DB needed)
+4. Check for duplicate run (see Duplicate Detection below) — exit immediately if duplicate
+5. Find all comments in the PR and process each eligible `@claude` comment (see rules below)
+6. Reply to the triggering `@claude resolve` comment with a sweep summary
 
 ---
 
-## Git Setup (do this before any commit or push)
+## Git Setup (do this first, before checkout)
 
 ```bash
 export GH_TOKEN="$BOT_PAT"
-git config user.name "claude-bot"
-git config user.email "claude-bot@users.noreply.github.com"
+git config --global user.name "claude-bot"
+git config --global user.email "claude-bot@users.noreply.github.com"
 git remote set-url origin https://claude-bot:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
 ```
 
-`BOT_PAT` is available as an environment variable in your Routine environment. `GH_TOKEN` must be set so the `gh` CLI authenticates as `claude-bot`.
+`BOT_PAT` is available as an environment variable in your Routine environment. `GH_TOKEN` must be set so the `gh` CLI authenticates as `claude-bot`. Use `--global` for git config since the working directory may not be a git repo yet when this runs.
 
-Checkout the PR branch before making any edits:
-```bash
-gh pr checkout <PR_NUMBER>
-```
+---
+
+## Duplicate Detection (run before processing any comments)
+
+Fetch the triggering `@claude resolve` comment (identified by the comment URL you received). Check its replies for any comment authored by `@claude-bot`. If one exists, this is a duplicate run — exit immediately without processing anything.
 
 ---
 
 ## Comment Processing Rules
 
-### Skip silently:
-- Any `@claude` comment that already has a reply from `@claude-bot` (handled in a prior sweep)
+### Skip silently (during the comment loop):
+- Any `@claude` comment that already has a reply from `@claude-bot` (handled in a prior sweep) — GitHub review comment API returns `position: null` for outdated comments; use this to detect them
 - The `@claude resolve` trigger comment itself
-- Outdated comments (on diff lines that no longer exist in the current PR)
-
-### Duplicate detection:
-Check if the triggering `@claude resolve` comment already has a reply from `@claude-bot`. If yes, this is a duplicate run — exit immediately without processing anything.
+- Outdated review comments (`position == null` in the GitHub API response)
 
 ### Fix request (comment asks you to change code):
 1. Edit the relevant files
-2. Run the verification gate:
+2. Verify the current branch is the PR feature branch (not `main` or `develop`) before pushing: `git branch --show-current`
+3. Run the verification gate:
    ```bash
    yarn lint
    npx tsc --noEmit
    ```
-3. If verification fails:
+4. If verification fails:
    - Attempt to self-heal the failures
    - If the fix is unambiguous → apply it, re-run verification, proceed
    - If the fix is ambiguous → reply to the comment asking for clarification; skip this fix for now
-4. Commit with message: `fix: <brief description> (resolves @claude-bot comment)`
+5. Commit with message: `fix: <brief description> (resolves @claude-bot comment)`
    - One commit per fixed comment
-5. Push: `git push origin HEAD`
-6. Reply to the comment summarising what was changed
+6. Push: `git push origin HEAD`
+7. Reply to the comment summarising what was changed
 
 ### Question (comment asks why/how something works):
 1. Post a reply with the answer
@@ -88,8 +88,9 @@ Check if the triggering `@claude resolve` comment already has a reply from `@cla
 2. No code changes, no commit
 
 ### Push failure:
-- Reply to the `@claude resolve` trigger comment with the error message
-- Do not retry
+- Reply to the comment that triggered the push failure with the error
+- Continue processing remaining comments
+- Include failed fixes in the sweep summary (count as "failed")
 
 ---
 
@@ -97,7 +98,7 @@ Check if the triggering `@claude resolve` comment already has a reply from `@cla
 
 After processing all comments, reply to the `@claude resolve` comment:
 
-> Done. Fixed N issues, answered N questions, skipped N outdated comments.
+> Done. Fixed N, answered N, skipped N (outdated/already-handled), failed N.
 
 This reply also acts as the duplicate-detection marker — a future `@claude resolve` without a bot reply on it means it's a fresh sweep.
 

--- a/.github/workflows/claude-resolve.yml
+++ b/.github/workflows/claude-resolve.yml
@@ -31,7 +31,7 @@ jobs:
             --arg url "$COMMENT_URL" \
             '{"text": "PR number: \($pr)\nTriggering comment URL: \($url)"}')
 
-          curl -sf -X POST "$ROUTINE_URL" \
+          curl -sfS -X POST "$ROUTINE_URL" \
             -H "Authorization: Bearer $ROUTINE_TOKEN" \
             -H "Content-Type: application/json" \
             -d "$payload"

--- a/.github/workflows/claude-resolve.yml
+++ b/.github/workflows/claude-resolve.yml
@@ -1,0 +1,37 @@
+name: Claude Bot — Resolve PR Comments
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  claude-resolve:
+    # Only fire when:
+    # - comment is by the repo owner
+    # - comment contains "@claude resolve"
+    # - the issue is actually a PR
+    # - the PR is open
+    if: >-
+      github.event.comment.user.login == 'SlatinskyJ' &&
+      contains(github.event.comment.body, '@claude resolve') &&
+      github.event.issue.pull_request != null &&
+      github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fire Claude Routine
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+          ROUTINE_URL: ${{ secrets.CLAUDE_ROUTINE_URL }}
+          ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_TOKEN }}
+        run: |
+          payload=$(jq -n \
+            --arg pr "$PR_NUMBER" \
+            --arg url "$COMMENT_URL" \
+            '{"text": "PR number: \($pr)\nTriggering comment URL: \($url)"}')
+
+          curl -sf -X POST "$ROUTINE_URL" \
+            -H "Authorization: Bearer $ROUTINE_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$payload"

--- a/.github/workflows/claude-resolve.yml
+++ b/.github/workflows/claude-resolve.yml
@@ -8,12 +8,12 @@ jobs:
   claude-resolve:
     # Only fire when:
     # - comment is by the repo owner
-    # - comment contains "@claude resolve"
+    # - comment contains "bot: resolve"
     # - the issue is actually a PR
     # - the PR is open
     if: >-
       github.event.comment.user.login == 'SlatinskyJ' &&
-      contains(github.event.comment.body, '@claude resolve') &&
+      contains(github.event.comment.body, 'bot: resolve') &&
       github.event.issue.pull_request != null &&
       github.event.issue.state == 'open'
     runs-on: ubuntu-latest

--- a/docs/superpowers/plans/2026-06-16-claude-github-bot.md
+++ b/docs/superpowers/plans/2026-06-16-claude-github-bot.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Wire up a Claude Code Routine that sweeps `@claude` PR comments when the repo owner posts `@claude resolve`, applying fixes and answering questions as a dedicated `@claude-bot` GitHub account.
+**Goal:** Wire up a Claude Code Routine that sweeps `bot:` PR comments when the repo owner posts `bot: resolve`, applying fixes and answering questions as a dedicated `@claude-bot` GitHub account.
 
-**Architecture:** GitHub Actions workflow listens for `@claude resolve` PR comments (owner-only) and POSTs to a Claude Code Routine's API trigger endpoint. The Routine runs on Anthropic's cloud, reads `.github/claude-bot.md` for project context, processes all pending `@claude` comments in the PR (fixes or answers each), then replies to the trigger comment with a sweep summary.
+**Architecture:** GitHub Actions workflow listens for `bot: resolve` PR comments (owner-only) and POSTs to a Claude Code Routine's API trigger endpoint. The Routine runs on Anthropic's cloud, reads `.github/claude-bot.md` for project context, processes all pending `bot:` comments in the PR (fixes or answers each), then replies to the trigger comment with a sweep summary.
 
 **Tech Stack:** GitHub Actions (`issue_comment` trigger), Claude Code Routines (API trigger), `gh` CLI / GitHub REST API, `jq`, `yarn`, TypeScript/Next.js (the app being edited by the bot)
 
@@ -36,12 +36,12 @@ jobs:
   claude-resolve:
     # Only fire when:
     # - comment is by the repo owner
-    # - comment contains "@claude resolve"
+    # - comment contains "bot: resolve"
     # - the issue is actually a PR
     # - the PR is open
     if: |
       github.event.comment.user.login == 'SlatinskyJ' &&
-      contains(github.event.comment.body, '@claude resolve') &&
+      contains(github.event.comment.body, 'bot: resolve') &&
       github.event.issue.pull_request != null &&
       github.event.issue.state == 'open'
     runs-on: ubuntu-latest
@@ -69,7 +69,7 @@ jobs:
 
 ```bash
 git add .github/workflows/claude-resolve.yml
-git commit -m "feat: add GitHub Actions workflow to fire Claude Routine on @claude resolve"
+git commit -m "feat: add GitHub Actions workflow to fire Claude Routine on bot: resolve"
 ```
 
 ---
@@ -84,7 +84,7 @@ git commit -m "feat: add GitHub Actions workflow to fire Claude Routine on @clau
 ```markdown
 # Claude Bot — Project Context & Operating Instructions
 
-You are `@claude-bot`, a Claude Code Routine acting on the cm-drozdi repository (cmdrozdi.cz). You process `@claude` PR comments posted by the repo owner (`SlatinskyJ`) — applying code fixes and answering questions.
+You are `@claude-bot`, a Claude Code Routine acting on the cm-drozdi repository (cmdrozdi.cz). You process `bot:` PR comments posted by the repo owner (`SlatinskyJ`) — applying code fixes and answering questions.
 
 ---
 
@@ -114,8 +114,8 @@ When triggered, you receive a PR number and a triggering comment URL. Your job:
 1. Configure git and authenticate (see Git Setup below)
 2. Run `yarn install` (installs deps; postinstall runs `prisma generate` automatically — no DB needed)
 3. Find all comments in the PR
-4. Process each eligible `@claude` comment (see rules below)
-5. Reply to the triggering `@claude resolve` comment with a sweep summary
+4. Process each eligible `bot:` comment (see rules below)
+5. Reply to the triggering `bot: resolve` comment with a sweep summary
 
 ---
 
@@ -140,12 +140,12 @@ gh pr checkout <PR_NUMBER>
 ## Comment Processing Rules
 
 ### Skip silently:
-- Any `@claude` comment that already has a reply from `@claude-bot` (handled in a prior sweep)
-- The `@claude resolve` trigger comment itself
+- Any `bot:` comment that already has a reply from `@claude-bot` (handled in a prior sweep)
+- The `bot: resolve` trigger comment itself
 - Outdated comments (on diff lines that no longer exist in the current PR)
 
 ### Duplicate detection:
-Check if the triggering `@claude resolve` comment already has a reply from `@claude-bot`. If yes, this is a duplicate run — exit immediately without processing anything.
+Check if the triggering `bot: resolve` comment already has a reply from `@claude-bot`. If yes, this is a duplicate run — exit immediately without processing anything.
 
 ### Fix request (comment asks you to change code):
 1. Edit the relevant files
@@ -172,18 +172,18 @@ Check if the triggering `@claude resolve` comment already has a reply from `@cla
 2. No code changes, no commit
 
 ### Push failure:
-- Reply to the `@claude resolve` trigger comment with the error message
+- Reply to the `bot: resolve` trigger comment with the error message
 - Do not retry
 
 ---
 
 ## Sweep Summary
 
-After processing all comments, reply to the `@claude resolve` comment:
+After processing all comments, reply to the `bot: resolve` comment:
 
 > Done. Fixed N issues, answered N questions, skipped N outdated comments.
 
-This reply also acts as the duplicate-detection marker — a future `@claude resolve` without a bot reply on it means it's a fresh sweep.
+This reply also acts as the duplicate-detection marker — a future `bot: resolve` without a bot reply on it means it's a fresh sweep.
 
 ---
 
@@ -247,14 +247,14 @@ Type: Remote
 ```
 Read `.github/claude-bot.md` for project context and operating instructions.
 
-You have been triggered by an `@claude resolve` comment. The following context was provided:
+You have been triggered by an `bot: resolve` comment. The following context was provided:
 
 {{text}}
 
 Extract the PR number and triggering comment URL from the above text, then proceed according to `.github/claude-bot.md`.
 ```
 
-> **Note:** `{{text}}` may or may not be interpolated depending on how the Routine injects the POST body's `text` field. If the raw placeholder appears at runtime (not substituted), remove the `{{text}}` and instead instruct Claude to use the `gh` CLI to find the most recent `@claude resolve` comment on the PR as the trigger. Verify this on first run.
+> **Note:** `{{text}}` may or may not be interpolated depending on how the Routine injects the POST body's `text` field. If the raw placeholder appears at runtime (not substituted), remove the `{{text}}` and instead instruct Claude to use the `gh` CLI to find the most recent `bot: resolve` comment on the PR as the trigger. Verify this on first run.
 
 - [ ] **Step 3: Set trigger to API**
 
@@ -297,18 +297,18 @@ Value: the Routine bearer token from Task 4 Step 5.
 
 Push a small throwaway branch from `develop` and open a draft PR.
 
-- [ ] **Step 2: Leave a test `@claude` comment**
+- [ ] **Step 2: Leave a test `bot:` comment**
 
 On any line in the diff, add an inline comment:
 ```
 @claude Add a comment explaining what this line does
 ```
 
-- [ ] **Step 3: Post `@claude resolve`**
+- [ ] **Step 3: Post `bot: resolve`**
 
 As `SlatinskyJ`, post a top-level PR comment:
 ```
-@claude resolve
+bot: resolve
 ```
 
 - [ ] **Step 4: Verify GitHub Actions fired**
@@ -321,7 +321,7 @@ Go to `claude.ai/code/routines` → `cm-drozdi PR Resolver` → run history. Con
 
 - [ ] **Step 6: Verify bot replied**
 
-Check the PR — `@claude-bot` should have replied to the `@claude` comment and posted a sweep summary on the `@claude resolve` comment.
+Check the PR — `@claude-bot` should have replied to the `bot:` comment and posted a sweep summary on the `bot: resolve` comment.
 
 - [ ] **Step 7: Close and delete the test PR/branch**
 

--- a/docs/superpowers/plans/2026-06-16-claude-github-bot.md
+++ b/docs/superpowers/plans/2026-06-16-claude-github-bot.md
@@ -123,12 +123,12 @@ When triggered, you receive a PR number and a triggering comment URL. Your job:
 
 ```bash
 export GH_TOKEN="$BOT_PAT"
-git config user.name "claude-bot-cmdrozdi"
+git config user.name "cmdrozdi-bot"
 git config user.email "claude-bot@users.noreply.github.com"
 git remote set-url origin https://claude-bot:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
 ```
 
-`BOT_PAT` is available as an environment variable in your Routine environment. `GH_TOKEN` must be set so the `gh` CLI authenticates as `claude-bot-cmdrozdi`.
+`BOT_PAT` is available as an environment variable in your Routine environment. `GH_TOKEN` must be set so the `gh` CLI authenticates as `cmdrozdi-bot`.
 
 Checkout the PR branch before making any edits:
 ```bash
@@ -211,21 +211,21 @@ git commit -m "feat: add claude-bot context file for Claude Code Routine"
 
 - [ ] **Step 1: Check username availability**
 
-Go to `https://github.com/claude-bot` — if the account exists and is not yours, use `claude-bot-cmdrozdi` instead. Update `.github/claude-bot.md` and the workflow git config accordingly if you use a different name.
+Go to `https://github.com/claude-bot` — if the account exists and is not yours, use `cmdrozdi-bot` instead. Update `.github/claude-bot.md` and the workflow git config accordingly if you use a different name.
 
 - [ ] **Step 2: Create the account**
 
-Sign up at github.com with a new email address. Set username to `claude-bot-cmdrozdi` (or fallback).
+Sign up at github.com with a new email address. Set username to `cmdrozdi-bot` (or fallback).
 
 - [ ] **Step 3: Grant repo access**
 
-In the cm-drozdi repo settings → Collaborators → Add `claude-bot-cmdrozdi` with **Write** role.
+In the cm-drozdi repo settings → Collaborators → Add `cmdrozdi-bot` with **Write** role.
 
-Accept the invitation from the `claude-bot-cmdrozdi` account.
+Accept the invitation from the `cmdrozdi-bot` account.
 
-- [ ] **Step 4: Generate a PAT for `claude-bot-cmdrozdi`**
+- [ ] **Step 4: Generate a PAT for `cmdrozdi-bot`**
 
-Logged in as `claude-bot-cmdrozdi`:
+Logged in as `cmdrozdi-bot`:
 - Go to Settings → Developer settings → Personal access tokens → Fine-grained tokens (or classic)
 - Classic token, scope: `repo`
 - No expiry (or set a long expiry you'll remember to rotate)

--- a/docs/superpowers/plans/2026-06-16-claude-github-bot.md
+++ b/docs/superpowers/plans/2026-06-16-claude-github-bot.md
@@ -1,0 +1,330 @@
+# Claude GitHub Bot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire up a Claude Code Routine that sweeps `@claude` PR comments when the repo owner posts `@claude resolve`, applying fixes and answering questions as a dedicated `@claude-bot` GitHub account.
+
+**Architecture:** GitHub Actions workflow listens for `@claude resolve` PR comments (owner-only) and POSTs to a Claude Code Routine's API trigger endpoint. The Routine runs on Anthropic's cloud, reads `.github/claude-bot.md` for project context, processes all pending `@claude` comments in the PR (fixes or answers each), then replies to the trigger comment with a sweep summary.
+
+**Tech Stack:** GitHub Actions (`issue_comment` trigger), Claude Code Routines (API trigger), `gh` CLI / GitHub REST API, `jq`, `yarn`, TypeScript/Next.js (the app being edited by the bot)
+
+---
+
+### Task 1: GitHub Actions Workflow
+
+**Files:**
+- Create: `.github/workflows/claude-resolve.yml`
+
+- [ ] **Step 1: Create `.github/` directory and workflow file**
+
+```bash
+mkdir -p .github/workflows
+```
+
+- [ ] **Step 2: Write the workflow**
+
+Create `.github/workflows/claude-resolve.yml`:
+
+```yaml
+name: Claude Bot — Resolve PR Comments
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  claude-resolve:
+    # Only fire when:
+    # - comment is by the repo owner
+    # - comment contains "@claude resolve"
+    # - the issue is actually a PR
+    # - the PR is open
+    if: |
+      github.event.comment.user.login == 'SlatinskyJ' &&
+      contains(github.event.comment.body, '@claude resolve') &&
+      github.event.issue.pull_request != null &&
+      github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fire Claude Routine
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+          ROUTINE_URL: ${{ secrets.CLAUDE_ROUTINE_URL }}
+          ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_TOKEN }}
+        run: |
+          payload=$(jq -n \
+            --arg pr "$PR_NUMBER" \
+            --arg url "$COMMENT_URL" \
+            '{"text": "PR number: \($pr)\nTriggering comment URL: \($url)"}')
+
+          curl -sf -X POST "$ROUTINE_URL" \
+            -H "Authorization: Bearer $ROUTINE_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$payload"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/claude-resolve.yml
+git commit -m "feat: add GitHub Actions workflow to fire Claude Routine on @claude resolve"
+```
+
+---
+
+### Task 2: Bot Context File
+
+**Files:**
+- Create: `.github/claude-bot.md`
+
+- [ ] **Step 1: Write `.github/claude-bot.md`**
+
+```markdown
+# Claude Bot — Project Context & Operating Instructions
+
+You are `@claude-bot`, a Claude Code Routine acting on the cm-drozdi repository (cmdrozdi.cz). You process `@claude` PR comments posted by the repo owner (`SlatinskyJ`) — applying code fixes and answering questions.
+
+---
+
+## Project Overview
+
+**Stack:** Next.js 14 App Router, tRPC, Prisma, NextAuth v4, Tailwind, NextUI (mid-migration to shadcn/ui).
+
+**Path aliases (tsconfig):**
+- `~/*` → `src/*`
+- `@public/*` → `public/*`
+- `@components/*` → `src/app/_components/*`
+
+**Branching:** `develop` is the integration branch. `main` is production-only — never commit or push to `main`. PRs target `develop`.
+
+**Key architecture notes:**
+- tRPC routers live in `src/server/api/routers/`. All procedures pass through `timingMiddleware` and `dateMiddleware` (auto timezone-adjusts `Date` fields — don't double-adjust).
+- Auth: NextAuth v4 in `src/server/auth.ts`. `UserRole` enum: `GUEST=0`, `MEMBER=1`, `ADMIN=2`.
+- Env vars validated via `@t3-oss/env-nextjs` in `src/env.js` — any new env var needs schema + `runtimeEnv` entry there.
+- `prisma/schema.prisma` is the domain model source of truth.
+
+---
+
+## Your Role
+
+When triggered, you receive a PR number and a triggering comment URL. Your job:
+
+1. Configure git and authenticate (see Git Setup below)
+2. Run `yarn install` (installs deps; postinstall runs `prisma generate` automatically — no DB needed)
+3. Find all comments in the PR
+4. Process each eligible `@claude` comment (see rules below)
+5. Reply to the triggering `@claude resolve` comment with a sweep summary
+
+---
+
+## Git Setup (do this before any commit or push)
+
+```bash
+export GH_TOKEN="$BOT_PAT"
+git config user.name "claude-bot"
+git config user.email "claude-bot@users.noreply.github.com"
+git remote set-url origin https://claude-bot:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
+```
+
+`BOT_PAT` is available as an environment variable in your Routine environment. `GH_TOKEN` must be set so the `gh` CLI authenticates as `claude-bot`.
+
+Checkout the PR branch before making any edits:
+```bash
+gh pr checkout <PR_NUMBER>
+```
+
+---
+
+## Comment Processing Rules
+
+### Skip silently:
+- Any `@claude` comment that already has a reply from `@claude-bot` (handled in a prior sweep)
+- The `@claude resolve` trigger comment itself
+- Outdated comments (on diff lines that no longer exist in the current PR)
+
+### Duplicate detection:
+Check if the triggering `@claude resolve` comment already has a reply from `@claude-bot`. If yes, this is a duplicate run — exit immediately without processing anything.
+
+### Fix request (comment asks you to change code):
+1. Edit the relevant files
+2. Run the verification gate:
+   ```bash
+   yarn lint
+   npx tsc --noEmit
+   ```
+3. If verification fails:
+   - Attempt to self-heal the failures
+   - If the fix is unambiguous → apply it, re-run verification, proceed
+   - If the fix is ambiguous → reply to the comment asking for clarification; skip this fix for now
+4. Commit with message: `fix: <brief description> (resolves @claude-bot comment)`
+   - One commit per fixed comment
+5. Push: `git push origin HEAD`
+6. Reply to the comment summarising what was changed
+
+### Question (comment asks why/how something works):
+1. Post a reply with the answer
+2. No code changes, no commit
+
+### Ambiguous (intent is unclear):
+1. Post a reply asking for clarification
+2. No code changes, no commit
+
+### Push failure:
+- Reply to the `@claude resolve` trigger comment with the error message
+- Do not retry
+
+---
+
+## Sweep Summary
+
+After processing all comments, reply to the `@claude resolve` comment:
+
+> Done. Fixed N issues, answered N questions, skipped N outdated comments.
+
+This reply also acts as the duplicate-detection marker — a future `@claude resolve` without a bot reply on it means it's a fresh sweep.
+
+---
+
+## Constraints
+
+- **Never commit or push to `main`**
+- **Never push to `develop` directly** — only to the PR's feature branch
+- Skip comments that discuss future work or out-of-scope changes (reply flagging them as out of scope instead)
+- Follow existing code patterns; don't introduce abstractions beyond what the fix requires
+- No test suite exists — the only verification gate is `yarn lint` + `npx tsc --noEmit`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/claude-bot.md
+git commit -m "feat: add claude-bot context file for Claude Code Routine"
+```
+
+---
+
+### Task 3: Manual — Create Bot GitHub Account
+
+> These steps cannot be automated. Complete them in your browser.
+
+- [ ] **Step 1: Check username availability**
+
+Go to `https://github.com/claude-bot` — if the account exists and is not yours, use `claude-bot-cmdrozdi` instead. Update `.github/claude-bot.md` and the workflow git config accordingly if you use a different name.
+
+- [ ] **Step 2: Create the account**
+
+Sign up at github.com with a new email address. Set username to `claude-bot` (or fallback).
+
+- [ ] **Step 3: Grant repo access**
+
+In the cm-drozdi repo settings → Collaborators → Add `claude-bot` with **Write** role.
+
+Accept the invitation from the `claude-bot` account.
+
+- [ ] **Step 4: Generate a PAT for `claude-bot`**
+
+Logged in as `claude-bot`:
+- Go to Settings → Developer settings → Personal access tokens → Fine-grained tokens (or classic)
+- Classic token, scope: `repo`
+- No expiry (or set a long expiry you'll remember to rotate)
+- Copy the token — you'll need it in Tasks 4 and 5
+
+---
+
+### Task 4: Manual — Create Claude Code Routine
+
+> Complete in the Claude Code desktop app or at `claude.ai/code/routines`.
+
+- [ ] **Step 1: Create a new Routine**
+
+Name: `cm-drozdi PR Resolver`
+Type: Remote
+
+- [ ] **Step 2: Set the prompt**
+
+```
+Read `.github/claude-bot.md` for project context and operating instructions.
+
+You have been triggered by an `@claude resolve` comment. The following context was provided:
+
+{{text}}
+
+Extract the PR number and triggering comment URL from the above text, then proceed according to `.github/claude-bot.md`.
+```
+
+> **Note:** `{{text}}` may or may not be interpolated depending on how the Routine injects the POST body's `text` field. If the raw placeholder appears at runtime (not substituted), remove the `{{text}}` and instead instruct Claude to use the `gh` CLI to find the most recent `@claude resolve` comment on the PR as the trigger. Verify this on first run.
+
+- [ ] **Step 3: Set trigger to API**
+
+Trigger type: API
+
+- [ ] **Step 4: Add environment variable**
+
+In the Routine's environment/secrets section:
+```
+BOT_PAT = <the PAT generated in Task 3 Step 4>
+```
+
+- [ ] **Step 5: Save the Routine and copy the API credentials**
+
+After saving, the Routine will show:
+- **Endpoint URL** (the `/fire` URL)
+- **Bearer token**
+
+Copy both — needed in Task 5.
+
+---
+
+### Task 5: Manual — Add GitHub Actions Secrets
+
+> In the cm-drozdi repo on GitHub: Settings → Secrets and variables → Actions → New repository secret.
+
+- [ ] **Step 1: Add `CLAUDE_ROUTINE_URL`**
+
+Value: the Routine `/fire` endpoint URL from Task 4 Step 5.
+
+- [ ] **Step 2: Add `CLAUDE_ROUTINE_TOKEN`**
+
+Value: the Routine bearer token from Task 4 Step 5.
+
+---
+
+### Task 6: Smoke Test
+
+- [ ] **Step 1: Create a test PR**
+
+Push a small throwaway branch from `develop` and open a draft PR.
+
+- [ ] **Step 2: Leave a test `@claude` comment**
+
+On any line in the diff, add an inline comment:
+```
+@claude Add a comment explaining what this line does
+```
+
+- [ ] **Step 3: Post `@claude resolve`**
+
+As `SlatinskyJ`, post a top-level PR comment:
+```
+@claude resolve
+```
+
+- [ ] **Step 4: Verify GitHub Actions fired**
+
+Go to the repo's Actions tab → `Claude Bot — Resolve PR Comments`. Confirm the run appeared and succeeded (green).
+
+- [ ] **Step 5: Verify Routine fired**
+
+Go to `claude.ai/code/routines` → `cm-drozdi PR Resolver` → run history. Confirm a run appeared.
+
+- [ ] **Step 6: Verify bot replied**
+
+Check the PR — `@claude-bot` should have replied to the `@claude` comment and posted a sweep summary on the `@claude resolve` comment.
+
+- [ ] **Step 7: Close and delete the test PR/branch**
+
+```bash
+gh pr close <number> --delete-branch
+```

--- a/docs/superpowers/plans/2026-06-16-claude-github-bot.md
+++ b/docs/superpowers/plans/2026-06-16-claude-github-bot.md
@@ -123,12 +123,12 @@ When triggered, you receive a PR number and a triggering comment URL. Your job:
 
 ```bash
 export GH_TOKEN="$BOT_PAT"
-git config user.name "claude-bot"
+git config user.name "claude-bot-cmdrozdi"
 git config user.email "claude-bot@users.noreply.github.com"
 git remote set-url origin https://claude-bot:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
 ```
 
-`BOT_PAT` is available as an environment variable in your Routine environment. `GH_TOKEN` must be set so the `gh` CLI authenticates as `claude-bot`.
+`BOT_PAT` is available as an environment variable in your Routine environment. `GH_TOKEN` must be set so the `gh` CLI authenticates as `claude-bot-cmdrozdi`.
 
 Checkout the PR branch before making any edits:
 ```bash
@@ -215,17 +215,17 @@ Go to `https://github.com/claude-bot` — if the account exists and is not yours
 
 - [ ] **Step 2: Create the account**
 
-Sign up at github.com with a new email address. Set username to `claude-bot` (or fallback).
+Sign up at github.com with a new email address. Set username to `claude-bot-cmdrozdi` (or fallback).
 
 - [ ] **Step 3: Grant repo access**
 
-In the cm-drozdi repo settings → Collaborators → Add `claude-bot` with **Write** role.
+In the cm-drozdi repo settings → Collaborators → Add `claude-bot-cmdrozdi` with **Write** role.
 
-Accept the invitation from the `claude-bot` account.
+Accept the invitation from the `claude-bot-cmdrozdi` account.
 
-- [ ] **Step 4: Generate a PAT for `claude-bot`**
+- [ ] **Step 4: Generate a PAT for `claude-bot-cmdrozdi`**
 
-Logged in as `claude-bot`:
+Logged in as `claude-bot-cmdrozdi`:
 - Go to Settings → Developer settings → Personal access tokens → Fine-grained tokens (or classic)
 - Classic token, scope: `repo`
 - No expiry (or set a long expiry you'll remember to rotate)

--- a/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
+++ b/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
@@ -17,7 +17,7 @@ A Claude Code Routine that sweeps `@claude` PR comments on demand, applying code
 GitHub Actions workflow (.github/workflows/claude-resolve.yml)
   — issue_comment trigger, filtered to owner + "@claude resolve"
   — checks PR is open
-  — POSTs to Routine /fire endpoint with PR number, comment body, comment URL
+  — POSTs to Routine /fire endpoint with PR number, comment URL
        ↓
 Claude Code Routine (API trigger, runs on Anthropic cloud)
   — reads .github/claude-bot.md for project context
@@ -60,7 +60,7 @@ Claude Code Routine (API trigger, runs on Anthropic cloud)
    - Filters to comments by the repo owner only
    - Filters to comments containing `@claude resolve`
    - Checks the PR is open (exits silently if closed/merged)
-   - POSTs to Routine `/fire` with: PR number, comment body, comment URL
+   - POSTs to Routine `/fire` with: PR number, comment URL
 4. Routine fires; Claude reads `.github/claude-bot.md` for project context
 5. Claude checks if this specific `@claude resolve` comment already has a reply from `@claude-bot` — if yes, this is a duplicate run, exit immediately
 6. Claude finds all `@claude` comments in the PR and processes them
@@ -160,7 +160,6 @@ Read `.github/claude-bot.md` for project context and operating instructions.
 You have been triggered by an `@claude resolve` comment.
 PR number: {{pr_number}}
 Triggering comment URL: {{comment_url}}
-Triggering comment body: {{comment_body}}
 
 Find all @claude comments in this PR and process them per the instructions in `.github/claude-bot.md`.
 When done, reply to the triggering comment with a sweep summary.
@@ -178,7 +177,7 @@ Steps:
 1. Filter: comment author must be repo owner (`SlatinskyJ`)
 2. Filter: comment body must contain `@claude resolve`
 3. Check PR is open via GitHub API; exit silently if closed/merged
-4. POST to `${{ secrets.CLAUDE_ROUTINE_URL }}` with bearer token `${{ secrets.CLAUDE_ROUTINE_TOKEN }}` and body containing PR number, comment URL, comment body
+4. POST to `${{ secrets.CLAUDE_ROUTINE_URL }}` with bearer token `${{ secrets.CLAUDE_ROUTINE_TOKEN }}` and body containing PR number, comment URL
 
 No checkout needed — the Routine clones the repo itself.
 

--- a/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
+++ b/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
@@ -5,17 +5,17 @@
 
 ## Overview
 
-A Claude Code Routine that sweeps `@claude` PR comments on demand, applying code fixes and answering questions, posting results as a dedicated bot GitHub account (`cmdrozdi-bot`).
+A Claude Code Routine that sweeps `bot:` PR comments on demand, applying code fixes and answering questions, posting results as a dedicated bot GitHub account (`cmdrozdi-bot`).
 
 ---
 
 ## Architecture
 
 ```
-@claude resolve comment (posted by repo owner)
+bot: resolve comment (posted by repo owner)
        ↓
 GitHub Actions workflow (.github/workflows/claude-resolve.yml)
-  — issue_comment trigger, filtered to owner + "@claude resolve"
+  — issue_comment trigger, filtered to owner + "bot: resolve"
   — checks PR is open
   — POSTs to Routine /fire endpoint with PR number, comment URL
        ↓
@@ -23,7 +23,7 @@ Claude Code Routine (API trigger, runs on Anthropic cloud)
   — reads .github/claude-bot.md for project context
   — processes all pending @claude comments in the PR
   — pushes fixes, posts replies as claude-bot account
-  — replies to @claude resolve with sweep summary
+  — replies to bot: resolve with sweep summary
 ```
 
 ### Claude Code Routine
@@ -55,16 +55,16 @@ Claude Code Routine (API trigger, runs on Anthropic cloud)
 ## Trigger Flow
 
 1. User leaves one or more `@claude <instruction>` comments on a PR
-2. When ready for a sweep, user posts `@claude resolve` in the PR
+2. When ready for a sweep, user posts `bot: resolve` in the PR
 3. GitHub Actions fires on the `issue_comment` event:
    - Filters to comments by the repo owner only
-   - Filters to comments containing `@claude resolve`
+   - Filters to comments containing `bot: resolve`
    - Checks the PR is open (exits silently if closed/merged)
    - POSTs to Routine `/fire` with: PR number, comment URL
 4. Routine fires; Claude reads `.github/claude-bot.md` for project context
-5. Claude checks if this specific `@claude resolve` comment already has a reply from `@claude-bot` — if yes, this is a duplicate run, exit immediately
-6. Claude finds all `@claude` comments in the PR and processes them
-7. Claude replies to the `@claude resolve` comment with a sweep summary
+5. Claude checks if this specific `bot: resolve` comment already has a reply from `@claude-bot` — if yes, this is a duplicate run, exit immediately
+6. Claude finds all `bot:` comments in the PR and processes them
+7. Claude replies to the `bot: resolve` comment with a sweep summary
 
 ---
 
@@ -85,8 +85,8 @@ Node version: trust Anthropic's cloud environment (repo requires >=20; Routine i
 ## Comment Processing Rules
 
 **Skip (silently):**
-- Any `@claude` comment that already has a reply from `@claude-bot` → handled in a prior sweep
-- The `@claude resolve` trigger comment itself
+- Any `bot:` comment that already has a reply from `@claude-bot` → handled in a prior sweep
+- The `bot: resolve` trigger comment itself
 - Outdated comments (on code lines no longer in the current diff)
 
 **Fix request** (comment asks Claude to change code):
@@ -110,17 +110,17 @@ Node version: trust Anthropic's cloud environment (repo requires >=20; Routine i
 2. No code changes
 
 **Push failure:**
-- Reply to the `@claude resolve` trigger comment with the error; do not retry silently
+- Reply to the `bot: resolve` trigger comment with the error; do not retry silently
 
 ---
 
 ## Sweep Completion
 
-After processing all comments, the bot replies to the `@claude resolve` comment:
+After processing all comments, the bot replies to the `bot: resolve` comment:
 
 > Done. Fixed 2 issues, answered 1 question, skipped 1 outdated comment.
 
-This reply is also the duplicate-detection marker for future runs. The user can post new `@claude` comments and trigger `@claude resolve` again for another sweep — each sweep is independent.
+This reply is also the duplicate-detection marker for future runs. The user can post new `bot:` comments and trigger `bot: resolve` again for another sweep — each sweep is independent.
 
 ---
 
@@ -142,11 +142,11 @@ Lives in the repo (versioned). The Routine reads it at the start of every run. T
 
 Sections:
 - **Project overview** — condensed from `CLAUDE.md`: T3 stack, branching rules, path aliases, tRPC/auth/Prisma notes, verification gate
-- **Bot role** — process all pending `@claude` comments in the triggered PR
+- **Bot role** — process all pending `bot:` comments in the triggered PR
 - **Verification gate** — `yarn lint` + `npx tsc --noEmit`; self-heal failures; post comment if ambiguous
 - **Commit conventions** — `fix: <description> (resolves @claude comment)`; bot account as author; one commit per fix
 - **Constraints** — never touch `main`; skip outdated comments; skip already-answered comments; don't apply fixes to future-work comments (flag them)
-- **Trigger comment** — `@claude resolve` starts the sweep; do not process it as a task
+- **Trigger comment** — `bot: resolve` starts the sweep; do not process it as a task
 
 Full draft is written as part of the implementation.
 
@@ -157,7 +157,7 @@ Full draft is written as part of the implementation.
 ```
 Read `.github/claude-bot.md` for project context and operating instructions.
 
-You have been triggered by an `@claude resolve` comment. Context:
+You have been triggered by an `bot: resolve` comment. Context:
 
 {{text}}
 
@@ -174,7 +174,7 @@ Trigger: `issue_comment` → `created`
 
 Steps:
 1. Filter: comment author must be repo owner (`SlatinskyJ`)
-2. Filter: comment body must contain `@claude resolve`
+2. Filter: comment body must contain `bot: resolve`
 3. Check PR is open via GitHub API; exit silently if closed/merged
 4. POST to `${{ secrets.CLAUDE_ROUTINE_URL }}` with bearer token `${{ secrets.CLAUDE_ROUTINE_TOKEN }}` and body containing PR number, comment URL
 

--- a/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
+++ b/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-A Claude Code Routine that sweeps `@claude` PR comments on demand, applying code fixes and answering questions, posting results as a dedicated bot GitHub account (`claude-bot-cmdrozdi`).
+A Claude Code Routine that sweeps `@claude` PR comments on demand, applying code fixes and answering questions, posting results as a dedicated bot GitHub account (`cmdrozdi-bot`).
 
 ---
 
@@ -37,7 +37,7 @@ Claude Code Routine (API trigger, runs on Anthropic cloud)
 
 ### Bot GitHub Account
 
-- **Username:** `claude-bot-cmdrozdi` (verify availability; fall back to `claude-bot-cmdrozdi` if taken)
+- **Username:** `cmdrozdi-bot` (verify availability; fall back to `cmdrozdi-bot` if taken)
 - **Permissions:** write access to cm-drozdi repo
 - **PAT scope:** `repo` (covers commits, PR comments, branch push)
 - **PAT storage:** Routine environment variables section (never travels over the wire)
@@ -96,7 +96,7 @@ Node version: trust Anthropic's cloud environment (repo requires >=20; Routine i
    - If self-heal is clear → fix, re-verify, proceed
    - If self-heal is ambiguous → post a reply comment asking for clarification, skip this fix
 4. Commit to PR branch with message: `fix: <description> (resolves @claude-bot comment)`
-   - Commit author = `claude-bot-cmdrozdi`
+   - Commit author = `cmdrozdi-bot`
    - One commit per fixed comment
 5. Push
 6. Reply to the comment with a summary of what was changed
@@ -129,7 +129,7 @@ This reply is also the duplicate-detection marker for future runs. The user can 
 The Routine configures git using the bot PAT from its env vars before any commit/push:
 
 ```bash
-git config user.name "claude-bot-cmdrozdi"
+git config user.name "cmdrozdi-bot"
 git config user.email "claude-bot@users.noreply.github.com"
 git remote set-url origin https://claude-bot:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
 ```

--- a/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
+++ b/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
@@ -5,53 +5,101 @@
 
 ## Overview
 
-A Claude Code Routine that sweeps `@claude` PR comments on demand, applying code fixes and answering questions, posting results as a dedicated bot GitHub account.
+A Claude Code Routine that sweeps `@claude` PR comments on demand, applying code fixes and answering questions, posting results as a dedicated bot GitHub account (`claude-bot`).
 
 ---
 
 ## Architecture
 
+```
+@claude resolve comment (posted by repo owner)
+       ↓
+GitHub Actions workflow (.github/workflows/claude-resolve.yml)
+  — issue_comment trigger, filtered to owner + "@claude resolve"
+  — checks PR is open
+  — POSTs to Routine /fire endpoint with PR number, comment body, comment URL
+       ↓
+Claude Code Routine (API trigger, runs on Anthropic cloud)
+  — reads .github/claude-bot.md for project context
+  — processes all pending @claude comments in the PR
+  — pushes fixes, posts replies as claude-bot account
+  — replies to @claude resolve with sweep summary
+```
+
 ### Claude Code Routine
 
-- **Trigger type:** GitHub — PR comment events
-- **Filter:** comment body matches `@claude resolve`
+- **Trigger type:** API — HTTP POST to per-routine `/fire` endpoint
 - **Repository:** cm-drozdi
-- **Prompt:** short (see below); references `.github/claude-bot.md` in the repo for project context
 - **Runs on:** Anthropic-managed cloud infrastructure (no local machine required)
+- **Prompt:** short (see below); Routine reads `.github/claude-bot.md` from repo at runtime
+
+> **Note:** GitHub triggers for Routines are research-preview and do not support private repositories. GitHub Actions is used as the event bridge instead.
 
 ### Bot GitHub Account
 
-A dedicated GitHub account (name TBD, e.g. `cmdrozdi-claude-bot`) with write access to cm-drozdi. All comments and commits the bot makes appear under this account, keeping the user's own comments visually distinct.
+- **Username:** `claude-bot` (verify availability; fall back to `claude-bot-cmdrozdi` if taken)
+- **Permissions:** write access to cm-drozdi repo
+- **PAT scope:** `repo` (covers commits, PR comments, branch push)
+- **PAT storage:** Routine environment variables section (never travels over the wire)
+- All comments and commits the bot makes appear under this account, keeping the user's own comments visually distinct
 
-- Generate a PAT for the bot account (scope: `repo` — covers commits, PR comments, and branch push)
-- Store the PAT as a secret accessible to the Routine (via MCP connector or Routine env var)
-- The Routine uses this PAT for all GitHub API calls (posting comments) and git operations (commit author + push)
+### GitHub Actions Secrets
+
+| Secret | Value |
+|--------|-------|
+| `CLAUDE_ROUTINE_URL` | Routine `/fire` endpoint URL |
+| `CLAUDE_ROUTINE_TOKEN` | Routine bearer token |
 
 ---
 
 ## Trigger Flow
 
-1. User leaves one or more `@claude <instruction>` comments on a PR (inline review threads or top-level)
+1. User leaves one or more `@claude <instruction>` comments on a PR
 2. When ready for a sweep, user posts `@claude resolve` in the PR
-3. Routine fires; Claude reads `.github/claude-bot.md` for project context
-4. Claude finds all `@claude` comments in the PR and processes them (see rules below)
-5. Claude replies to the `@claude resolve` comment with a sweep summary
+3. GitHub Actions fires on the `issue_comment` event:
+   - Filters to comments by the repo owner only
+   - Filters to comments containing `@claude resolve`
+   - Checks the PR is open (exits silently if closed/merged)
+   - POSTs to Routine `/fire` with: PR number, comment body, comment URL
+4. Routine fires; Claude reads `.github/claude-bot.md` for project context
+5. Claude checks if this specific `@claude resolve` comment already has a bot reply — if yes, this is a duplicate run, exit immediately
+6. Claude finds all `@claude` comments in the PR and processes them
+7. Claude replies to the `@claude resolve` comment with a sweep summary
+
+---
+
+## Sweep Startup
+
+At the start of every sweep, before processing any comments:
+
+```bash
+yarn install        # also runs prisma generate via postinstall
+```
+
+No `DATABASE_URL` needed — `prisma generate` reads `prisma/schema.prisma` only (no live DB). Lint and typecheck are static and also require no DB.
+
+Node version: trust Anthropic's cloud environment (repo requires >=20; Routine infra assumed to meet this).
 
 ---
 
 ## Comment Processing Rules
 
 **Skip (silently):**
-- Any `@claude` comment that already has a reply from the bot account → already handled in a prior sweep
-- Any `@claude resolve` comment that already has a bot reply → this Routine run is a duplicate, exit immediately
-- Outdated comments (comments on code lines that no longer exist in the current diff)
+- Any `@claude` comment that already has a reply from `claude-bot` → handled in a prior sweep
+- The `@claude resolve` trigger comment itself
+- Outdated comments (on code lines no longer in the current diff)
 
 **Fix request** (comment asks Claude to change code):
 1. Edit the relevant files
-2. Run verification gate: `yarn lint` + `npx tsc --noEmit`
-3. Commit to the PR branch (commit author = bot account)
-4. Push
-5. Reply to the comment with a summary of what was changed
+2. Run `yarn lint` + `npx tsc --noEmit`
+3. If verification fails → attempt to self-heal the failure
+   - If self-heal is clear → fix, re-verify, proceed
+   - If self-heal is ambiguous → post a reply comment asking for clarification, skip this fix
+4. Commit to PR branch with message: `fix: <description> (resolves @claude comment)`
+   - Commit author = `claude-bot`
+   - One commit per fixed comment
+5. Push
+6. Reply to the comment with a summary of what was changed
 
 **Question** (comment asks why/how something works):
 1. Post a reply comment with the answer
@@ -68,27 +116,39 @@ A dedicated GitHub account (name TBD, e.g. `cmdrozdi-claude-bot`) with write acc
 
 ## Sweep Completion
 
-After processing all comments, the bot replies to the `@claude resolve` comment with a summary, e.g.:
+After processing all comments, the bot replies to the `@claude resolve` comment:
 
 > Done. Fixed 2 issues, answered 1 question, skipped 1 outdated comment.
 
-This reply also serves as the duplicate-detection marker: a second `@claude resolve` with no bot reply is a fresh sweep; one with a bot reply is a duplicate and exits immediately.
+This reply is also the duplicate-detection marker for future runs. The user can post new `@claude` comments and trigger `@claude resolve` again for another sweep — each sweep is independent.
 
-The user can post new `@claude` comments after a sweep and trigger `@claude resolve` again for another pass.
+---
+
+## Git Authentication (in Routine)
+
+The Routine configures git using the bot PAT from its env vars before any commit/push:
+
+```bash
+git config user.name "claude-bot"
+git config user.email "claude-bot@users.noreply.github.com"
+git remote set-url origin https://claude-bot:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
+```
 
 ---
 
 ## `.github/claude-bot.md` — Content Structure
 
-This file lives in the repo (versioned) and is read by the Routine at the start of every run. The Routine prompt itself is minimal; all project knowledge lives here.
+Lives in the repo (versioned). The Routine reads it at the start of every run. The Routine prompt itself is minimal; all project knowledge lives here.
 
 Sections:
-- **Project overview** — condensed from `CLAUDE.md`: T3 stack, branching rules (`develop` integration branch, `main` production-only), path aliases, tRPC/auth/Prisma notes
+- **Project overview** — condensed from `CLAUDE.md`: T3 stack, branching rules, path aliases, tRPC/auth/Prisma notes, verification gate
 - **Bot role** — process all pending `@claude` comments in the triggered PR
-- **Verification gate** — `yarn lint` + `npx tsc --noEmit` must pass before any push
-- **Commit conventions** — follow repo style; bot account as author; one commit per logical fix
-- **Constraints** — never touch `main`; don't apply fixes to outdated comments; don't resolve comments about future work (flag them)
-- **Trigger comment** — `@claude resolve` starts the sweep; the bot must not process this comment as a task
+- **Verification gate** — `yarn lint` + `npx tsc --noEmit`; self-heal failures; post comment if ambiguous
+- **Commit conventions** — `fix: <description> (resolves @claude comment)`; bot account as author; one commit per fix
+- **Constraints** — never touch `main`; skip outdated comments; skip already-answered comments; don't apply fixes to future-work comments (flag them)
+- **Trigger comment** — `@claude resolve` starts the sweep; do not process it as a task
+
+Full draft is written as part of the implementation.
 
 ---
 
@@ -97,18 +157,36 @@ Sections:
 ```
 Read `.github/claude-bot.md` for project context and operating instructions.
 
-You have been triggered by an `@claude resolve` comment on PR #{{pr_number}} in the cm-drozdi repo.
-Find all `@claude` comments in this PR and process them according to the instructions in `.github/claude-bot.md`.
-When done, reply to the `@claude resolve` comment with a sweep summary.
+You have been triggered by an `@claude resolve` comment.
+PR number: {{pr_number}}
+Triggering comment URL: {{comment_url}}
+Triggering comment body: {{comment_body}}
+
+Find all @claude comments in this PR and process them per the instructions in `.github/claude-bot.md`.
+When done, reply to the triggering comment with a sweep summary.
 ```
 
-> **Implementation note:** Verify whether the Routine GitHub trigger injects context variables (e.g. `{{pr_number}}`, `{{comment_body}}`). If not, the prompt will need to instruct Claude to discover the PR number from the triggering event payload instead.
+> **Implementation note:** Verify whether the Routine API trigger injects the `text` field from the POST body as template variables (e.g. `{{pr_number}}`). If not, the prompt should instruct Claude to parse the raw `text` field payload instead.
+
+---
+
+## GitHub Actions Workflow (`.github/workflows/claude-resolve.yml`)
+
+Trigger: `issue_comment` → `created`
+
+Steps:
+1. Filter: comment author must be repo owner (`SlatinskyJ`)
+2. Filter: comment body must contain `@claude resolve`
+3. Check PR is open via GitHub API; exit silently if closed/merged
+4. POST to `${{ secrets.CLAUDE_ROUTINE_URL }}` with bearer token `${{ secrets.CLAUDE_ROUTINE_TOKEN }}` and body containing PR number, comment URL, comment body
+
+No checkout needed — the Routine clones the repo itself.
 
 ---
 
 ## Out of Scope
 
-- Polling or always-on infrastructure — runs only when `@claude resolve` is posted
-- Support for other repos — design is cm-drozdi specific for now; `.github/claude-bot.md` pattern is reusable
-- GitHub Actions — Routines replace this entirely
-- Automatic scheduling — purely on-demand
+- Polling or always-on infrastructure
+- Support for other repos (`.github/claude-bot.md` pattern is portable when needed)
+- Automatic scheduling
+- GitHub Copilot or GitHub Actions as the AI executor (Routine handles all intelligence)

--- a/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
+++ b/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
@@ -62,7 +62,7 @@ Claude Code Routine (API trigger, runs on Anthropic cloud)
    - Checks the PR is open (exits silently if closed/merged)
    - POSTs to Routine `/fire` with: PR number, comment body, comment URL
 4. Routine fires; Claude reads `.github/claude-bot.md` for project context
-5. Claude checks if this specific `@claude resolve` comment already has a bot reply — if yes, this is a duplicate run, exit immediately
+5. Claude checks if this specific `@claude resolve` comment already has a reply from `@claude-bot` — if yes, this is a duplicate run, exit immediately
 6. Claude finds all `@claude` comments in the PR and processes them
 7. Claude replies to the `@claude resolve` comment with a sweep summary
 
@@ -85,7 +85,7 @@ Node version: trust Anthropic's cloud environment (repo requires >=20; Routine i
 ## Comment Processing Rules
 
 **Skip (silently):**
-- Any `@claude` comment that already has a reply from `claude-bot` → handled in a prior sweep
+- Any `@claude` comment that already has a reply from `@claude-bot` → handled in a prior sweep
 - The `@claude resolve` trigger comment itself
 - Outdated comments (on code lines no longer in the current diff)
 
@@ -95,7 +95,7 @@ Node version: trust Anthropic's cloud environment (repo requires >=20; Routine i
 3. If verification fails → attempt to self-heal the failure
    - If self-heal is clear → fix, re-verify, proceed
    - If self-heal is ambiguous → post a reply comment asking for clarification, skip this fix
-4. Commit to PR branch with message: `fix: <description> (resolves @claude comment)`
+4. Commit to PR branch with message: `fix: <description> (resolves @claude-bot comment)`
    - Commit author = `claude-bot`
    - One commit per fixed comment
 5. Push

--- a/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
+++ b/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
@@ -157,15 +157,14 @@ Full draft is written as part of the implementation.
 ```
 Read `.github/claude-bot.md` for project context and operating instructions.
 
-You have been triggered by an `@claude resolve` comment.
-PR number: {{pr_number}}
-Triggering comment URL: {{comment_url}}
+You have been triggered by an `@claude resolve` comment. Context:
 
-Find all @claude comments in this PR and process them per the instructions in `.github/claude-bot.md`.
-When done, reply to the triggering comment with a sweep summary.
+{{text}}
+
+Parse the PR number and triggering comment URL from the above, then proceed according to `.github/claude-bot.md`.
 ```
 
-> **Implementation note:** Verify whether the Routine API trigger injects the `text` field from the POST body as template variables (e.g. `{{pr_number}}`). If not, the prompt should instruct Claude to parse the raw `text` field payload instead.
+> **Note:** `{{text}}` injects the raw API trigger payload. The setup script handles checkout; Claude only needs to parse the comment URL from the payload to post the sweep summary reply. Verify `{{text}}` is substituted on first run — if it appears literally, update the prompt to instruct Claude to read the incoming context directly.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
+++ b/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-A Claude Code Routine that sweeps `@claude` PR comments on demand, applying code fixes and answering questions, posting results as a dedicated bot GitHub account (`claude-bot`).
+A Claude Code Routine that sweeps `@claude` PR comments on demand, applying code fixes and answering questions, posting results as a dedicated bot GitHub account (`claude-bot-cmdrozdi`).
 
 ---
 
@@ -37,7 +37,7 @@ Claude Code Routine (API trigger, runs on Anthropic cloud)
 
 ### Bot GitHub Account
 
-- **Username:** `claude-bot` (verify availability; fall back to `claude-bot-cmdrozdi` if taken)
+- **Username:** `claude-bot-cmdrozdi` (verify availability; fall back to `claude-bot-cmdrozdi` if taken)
 - **Permissions:** write access to cm-drozdi repo
 - **PAT scope:** `repo` (covers commits, PR comments, branch push)
 - **PAT storage:** Routine environment variables section (never travels over the wire)
@@ -96,7 +96,7 @@ Node version: trust Anthropic's cloud environment (repo requires >=20; Routine i
    - If self-heal is clear → fix, re-verify, proceed
    - If self-heal is ambiguous → post a reply comment asking for clarification, skip this fix
 4. Commit to PR branch with message: `fix: <description> (resolves @claude-bot comment)`
-   - Commit author = `claude-bot`
+   - Commit author = `claude-bot-cmdrozdi`
    - One commit per fixed comment
 5. Push
 6. Reply to the comment with a summary of what was changed
@@ -129,7 +129,7 @@ This reply is also the duplicate-detection marker for future runs. The user can 
 The Routine configures git using the bot PAT from its env vars before any commit/push:
 
 ```bash
-git config user.name "claude-bot"
+git config user.name "claude-bot-cmdrozdi"
 git config user.email "claude-bot@users.noreply.github.com"
 git remote set-url origin https://claude-bot:${BOT_PAT}@github.com/SlatinskyJ/cm-drozdi.git
 ```

--- a/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
+++ b/docs/superpowers/specs/2026-06-16-claude-github-bot-design.md
@@ -1,0 +1,114 @@
+# Design — Claude GitHub Bot
+
+**Date:** 2026-06-16
+**Repo:** cm-drozdi (cmdrozdi.cz)
+
+## Overview
+
+A Claude Code Routine that sweeps `@claude` PR comments on demand, applying code fixes and answering questions, posting results as a dedicated bot GitHub account.
+
+---
+
+## Architecture
+
+### Claude Code Routine
+
+- **Trigger type:** GitHub — PR comment events
+- **Filter:** comment body matches `@claude resolve`
+- **Repository:** cm-drozdi
+- **Prompt:** short (see below); references `.github/claude-bot.md` in the repo for project context
+- **Runs on:** Anthropic-managed cloud infrastructure (no local machine required)
+
+### Bot GitHub Account
+
+A dedicated GitHub account (name TBD, e.g. `cmdrozdi-claude-bot`) with write access to cm-drozdi. All comments and commits the bot makes appear under this account, keeping the user's own comments visually distinct.
+
+- Generate a PAT for the bot account (scope: `repo` — covers commits, PR comments, and branch push)
+- Store the PAT as a secret accessible to the Routine (via MCP connector or Routine env var)
+- The Routine uses this PAT for all GitHub API calls (posting comments) and git operations (commit author + push)
+
+---
+
+## Trigger Flow
+
+1. User leaves one or more `@claude <instruction>` comments on a PR (inline review threads or top-level)
+2. When ready for a sweep, user posts `@claude resolve` in the PR
+3. Routine fires; Claude reads `.github/claude-bot.md` for project context
+4. Claude finds all `@claude` comments in the PR and processes them (see rules below)
+5. Claude replies to the `@claude resolve` comment with a sweep summary
+
+---
+
+## Comment Processing Rules
+
+**Skip (silently):**
+- Any `@claude` comment that already has a reply from the bot account → already handled in a prior sweep
+- Any `@claude resolve` comment that already has a bot reply → this Routine run is a duplicate, exit immediately
+- Outdated comments (comments on code lines that no longer exist in the current diff)
+
+**Fix request** (comment asks Claude to change code):
+1. Edit the relevant files
+2. Run verification gate: `yarn lint` + `npx tsc --noEmit`
+3. Commit to the PR branch (commit author = bot account)
+4. Push
+5. Reply to the comment with a summary of what was changed
+
+**Question** (comment asks why/how something works):
+1. Post a reply comment with the answer
+2. No code changes
+
+**Ambiguous** (intent unclear):
+1. Reply asking for clarification
+2. No code changes
+
+**Push failure:**
+- Reply to the `@claude resolve` trigger comment with the error; do not retry silently
+
+---
+
+## Sweep Completion
+
+After processing all comments, the bot replies to the `@claude resolve` comment with a summary, e.g.:
+
+> Done. Fixed 2 issues, answered 1 question, skipped 1 outdated comment.
+
+This reply also serves as the duplicate-detection marker: a second `@claude resolve` with no bot reply is a fresh sweep; one with a bot reply is a duplicate and exits immediately.
+
+The user can post new `@claude` comments after a sweep and trigger `@claude resolve` again for another pass.
+
+---
+
+## `.github/claude-bot.md` — Content Structure
+
+This file lives in the repo (versioned) and is read by the Routine at the start of every run. The Routine prompt itself is minimal; all project knowledge lives here.
+
+Sections:
+- **Project overview** — condensed from `CLAUDE.md`: T3 stack, branching rules (`develop` integration branch, `main` production-only), path aliases, tRPC/auth/Prisma notes
+- **Bot role** — process all pending `@claude` comments in the triggered PR
+- **Verification gate** — `yarn lint` + `npx tsc --noEmit` must pass before any push
+- **Commit conventions** — follow repo style; bot account as author; one commit per logical fix
+- **Constraints** — never touch `main`; don't apply fixes to outdated comments; don't resolve comments about future work (flag them)
+- **Trigger comment** — `@claude resolve` starts the sweep; the bot must not process this comment as a task
+
+---
+
+## Routine Prompt (stored in Routine config)
+
+```
+Read `.github/claude-bot.md` for project context and operating instructions.
+
+You have been triggered by an `@claude resolve` comment on PR #{{pr_number}} in the cm-drozdi repo.
+Find all `@claude` comments in this PR and process them according to the instructions in `.github/claude-bot.md`.
+When done, reply to the `@claude resolve` comment with a sweep summary.
+```
+
+> **Implementation note:** Verify whether the Routine GitHub trigger injects context variables (e.g. `{{pr_number}}`, `{{comment_body}}`). If not, the prompt will need to instruct Claude to discover the PR number from the triggering event payload instead.
+
+---
+
+## Out of Scope
+
+- Polling or always-on infrastructure — runs only when `@claude resolve` is posted
+- Support for other repos — design is cm-drozdi specific for now; `.github/claude-bot.md` pattern is reusable
+- GitHub Actions — Routines replace this entirely
+- Automatic scheduling — purely on-demand


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-resolve.yml` — GitHub Actions workflow that fires a Claude Code Routine when `bot: resolve` is posted on a PR by the repo owner
- Adds `.github/claude-bot.md` — operating instructions and project context for the `@cmdrozdi-bot` Routine
- Adds design spec and implementation plan under `docs/superpowers/`

## How it works

1. Leave `bot: <instruction>` comments on a PR (fix requests or questions)
2. Post `bot: resolve` when ready to sweep
3. GitHub Actions fires → POSTs to Claude Code Routine `/fire` endpoint
4. Routine runs on Anthropic cloud as `@cmdrozdi-bot`, processes all pending `bot:` comments, pushes fixes, posts answers, replies to trigger with a summary

## Prerequisites (already configured)

- `CLAUDE_ROUTINE_URL` and `CLAUDE_ROUTINE_TOKEN` in GHA secrets ✅
- `BOT_PAT` in Routine env vars ✅
- `cmdrozdi-bot` GitHub account with Write access to repo ✅

## Test plan

- [ ] After merge, open a test PR, leave a `bot:` comment, post `bot: resolve`
- [ ] Verify Actions workflow fires and Routine runs
- [ ] Verify `@cmdrozdi-bot` replies and posts sweep summary
- [ ] Close and delete test PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)