### PR TITLE
fix: add missing Anthropic headers to Routine fire call

### DIFF
--- a/.github/workflows/claude-resolve.yml
+++ b/.github/workflows/claude-resolve.yml
@@ -33,5 +33,7 @@ jobs:
 
           curl -sfS -X POST "$ROUTINE_URL" \
             -H "Authorization: Bearer $ROUTINE_TOKEN" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
             -H "Content-Type: application/json" \
             -d "$payload"


### PR DESCRIPTION
Adds `anthropic-version` and `anthropic-beta` headers required by the Routines API — without them the endpoint returns 400.