### PR TITLE
fix: trigger Claude resolve bot on pull_request_review too

### DIFF
--- a/.github/workflows/claude-resolve.yml
+++ b/.github/workflows/claude-resolve.yml
@@ -3,26 +3,38 @@ name: Claude Bot — Resolve PR Comments
 on:
   issue_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   claude-resolve:
     # Only fire when:
-    # - comment is by the repo owner
-    # - comment contains "bot: resolve"
-    # - the issue is actually a PR
+    # - comment/review is by the repo owner
+    # - comment/review body contains "bot: resolve"
     # - the PR is open
+    # (issue_comment fires for regular PR conversation comments;
+    #  pull_request_review fires for comments left via "Review changes")
     if: >-
-      github.event.comment.user.login == 'SlatinskyJ' &&
-      contains(github.event.comment.body, 'bot: resolve') &&
-      github.event.issue.pull_request != null &&
-      github.event.issue.state == 'open'
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.comment.user.login == 'SlatinskyJ' &&
+        contains(github.event.comment.body, 'bot: resolve') &&
+        github.event.issue.pull_request != null &&
+        github.event.issue.state == 'open'
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        github.event.review.user.login == 'SlatinskyJ' &&
+        contains(github.event.review.body, 'bot: resolve') &&
+        github.event.pull_request.state == 'open'
+      )
     runs-on: ubuntu-latest
 
     steps:
       - name: Fire Claude Routine
         env:
-          PR_NUMBER: ${{ github.event.issue.number }}
-          COMMENT_URL: ${{ github.event.comment.html_url }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          COMMENT_URL: ${{ github.event.comment.html_url || github.event.review.html_url }}
           ROUTINE_URL: ${{ secrets.CLAUDE_ROUTINE_URL }}
           ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- `claude-resolve.yml` only listened on `issue_comment`, so a `bot: resolve` comment left via GitHub's "Review changes" flow (which fires `pull_request_review`, not `issue_comment`) never triggered the bot. This is what happened on PR #13.
- Added `pull_request_review: [submitted]` as a second trigger, with matching owner/body/open-PR checks, and made `PR_NUMBER`/`COMMENT_URL` resolve from either event shape.

## Test plan
- [ ] Leave a plain PR comment containing `bot: resolve` — confirm `issue_comment` path still fires.
- [ ] Submit a review (Review changes -> Comment) with body `bot: resolve` — confirm `pull_request_review` path now fires.
- [ ] Confirm comments from other users or without `bot: resolve` still skip the job.