### PR TITLE
ci: skip CI checks on docs/plan-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,26 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!.agents/**'
+              - '!.claude/**'
+              - '!**/*.md'
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,6 +37,8 @@ jobs:
       - run: SKIP_ENV_VALIDATION=1 yarn lint
 
   typecheck:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,8 +51,9 @@ jobs:
       - run: SKIP_ENV_VALIDATION=1 yarn typecheck
 
   e2e:
+    needs: changes
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: needs.changes.outputs.code == 'true' && github.event.pull_request.draft == false
     services:
       postgres:
         image: postgres:16


### PR DESCRIPTION
## Summary
- Add a `changes` job (using `dorny/paths-filter`) to `.github/workflows/ci.yml` that detects whether a PR touched anything outside `docs/`, `.agents/`, `.claude/`, or `*.md`.
- `lint`, `typecheck`, and `e2e` now gate on `needs.changes.outputs.code == 'true'`. When false (doc/plan-only PR), the jobs report as skipped — which GitHub treats as a passing required status check — so the PR can merge without spinning up Postgres/Playwright/build.
- Vercel deployments still need a matching change in the dashboard (Project Settings → Git → Ignored Build Step), since that's not version-controlled. See PR description follow-up below.

## Vercel side (manual, dashboard-only)
Paste into **Project Settings → Git → Ignored Build Step**:
```bash
git diff --quiet HEAD^ HEAD -- . ':!docs' ':!**/*.md' ':!.claude' ':!.agents'
```
Exit 0 (no relevant diff) → Vercel skips the deployment (reports "skipped", not a failure). Exit 1 (relevant diff) → proceeds normally.

## Test plan
- [ ] Open a PR that only edits a file under `docs/superpowers/plans/` — confirm `lint`/`typecheck`/`e2e` show as skipped (not pending) and the PR is mergeable without waiting on them.
- [ ] Open a PR that edits a `src/` file — confirm all three jobs still run and gate merge as before.
- [ ] Paste the Ignored Build Step script into Vercel project settings and confirm a docs-only PR shows the Vercel check as skipped rather than triggering a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)