### PR TITLE
docs: track phase PRs by link instead of manual status

### DIFF
--- a/docs/superpowers/plans/2026-06-11-dependency-upgrade-master-plan.md
+++ b/docs/superpowers/plans/2026-06-11-dependency-upgrade-master-plan.md
@@ -231,15 +231,17 @@
 
 ## Tracking
 
-| Phase | PR | Status |
-|---|---|---|
-| 0 — Baseline | `chore/upgrade-phase-0-baseline` | merged |
-| 1 — Better Auth migration | `feat/upgrade-phase-1-better-auth` | merged |
-| 2 — E2E net + CI | `chore/upgrade-phase-2-e2e-ci` | in review |
-| 3 — Minor bumps | – | not started |
-| 4 — shadcn migration | – | not started |
-| 5 — React 19 / Next 16 | – | not started |
-| 6 — Tailwind 4 | – | not started |
-| 7 — Prisma 7 | – | not started |
-| 8 — Zod 4 | – | not started |
-| 9 — ESLint 10 | – | not started |
+Once a phase has an open PR, track that PR (`gh pr view <number>`) for live status instead of hand-editing a status column here. Only phases without a PR yet show "not started".
+
+| Phase | PR |
+|---|---|
+| 0 — Baseline | [#4](https://github.com/SlatinskyJ/cm-drozdi/pull/4) (merged) |
+| 1 — Better Auth migration | [#7](https://github.com/SlatinskyJ/cm-drozdi/pull/7) (merged) |
+| 2 — E2E net + CI | [#13](https://github.com/SlatinskyJ/cm-drozdi/pull/13) (merged) |
+| 3 — Minor bumps | not started |
+| 4 — shadcn migration | not started |
+| 5 — React 19 / Next 16 | not started |
+| 6 — Tailwind 4 | not started |
+| 7 — Prisma 7 | not started |
+| 8 — Zod 4 | not started |
+| 9 — ESLint 10 | not started |


### PR DESCRIPTION
## Summary
- Master plan tracking table now links each phase's PR (#4, #7, #13) instead of a hand-maintained status string.
- Live status comes from `gh pr view <number>` going forward, so progress is visible without editing the plan.

## Test plan
- [x] Docs-only change, no functional impact.