### PR TITLE
fix: CI docs-only skip filter never actually excluded docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          predicate-quantifier: every
           filters: |
             code:
               - '**'


### PR DESCRIPTION
## Summary
- `dorny/paths-filter` defaults to `predicate-quantifier: some` (OR across patterns), so the broad `**` pattern always matched and the `!docs/**` / `!.agents/**` / `!.claude/**` / `!**/*.md` exclusions added in #15 never actually excluded anything.
- Set `predicate-quantifier: every` so a file only counts as `code` if it matches every pattern (i.e. survives all the exclusions).
- Confirmed the bug live on PR #16 (docs-only change) — lint/typecheck ran instead of being skipped.

## Test plan
- [ ] Verify lint/typecheck show as skipped on a docs-only PR
- [ ] Verify lint/typecheck still run on a PR touching `src/**`